### PR TITLE
block_searchcourses: define AJAX_SCRIPT conditionally

### DIFF
--- a/result.php
+++ b/result.php
@@ -1,7 +1,10 @@
 <?php
 require_once('../../config.php');
 require_login();
-define('AJAX_SCRIPT', true);
+
+if(!defined('AJAX_SCRIPT')){
+    define('AJAX_SCRIPT', true);
+}
 require_once($CFG->libdir . '/datalib.php');
 global $CFG;
 $USER;


### PR DESCRIPTION
AJAX_SCRIPT is defined many, many places in Moodle.  Redefining it throws a awanring, so it should be defined conditionally. 
http://code.metager.de/source/search?q=AJAX_SCRIPT&project=moodle
