### PR TITLE
implements view capability

### DIFF
--- a/block_searchcourses.php
+++ b/block_searchcourses.php
@@ -30,7 +30,7 @@
  */
 class block_searchcourses extends block_base
 {
-    
+
     public function init()
     {
         $this->title = get_string('pluginname', 'block_searchcourses');
@@ -44,6 +44,21 @@ class block_searchcourses extends block_base
             'my' => true
         );
     }
+
+
+    /**
+     *
+     * {@inheritDoc}
+     * @see block_base::is_empty()
+     */
+    function is_empty() {
+        if ( !has_capability('blocks/searchcourses:view', $this->context) ) {
+            return true;
+        }
+        return parent::is_empty();
+    }
+
+
     public function get_content()
     {
         global $CFG,$PAGE;


### PR DESCRIPTION
This block defines its own view capability but it doesn't seem to be used

this commit uses the is_empty() method to implement the “blocks/searchcourses:view” capability